### PR TITLE
Refactor article and news controllers to improve reaction handling

### DIFF
--- a/src/controllers/help/get-article-by-id.ts
+++ b/src/controllers/help/get-article-by-id.ts
@@ -31,7 +31,7 @@ type TArticleWithPopulatedAuthors = {
     tags: string[];
     readTime: number;
     isPublished: boolean;
-    reactions: ArticleReactionItem | null;
+    reactions?: ArticleReactionItem[];
     createdAt: Date;
     updatedAt: Date;
 }
@@ -58,7 +58,7 @@ type TFormattedArticle = {
     collection_id: Schema.Types.ObjectId;
     tags: string[];
     read_time: number;
-    reactions?: ArticleReactionItem | null;
+    reaction?: ArticleReactionItem;
     created_at: Date;
     updated_at: Date;
 }
@@ -71,7 +71,7 @@ type TResponseData = {
 
 export const get_article_by_id = async ({ req, res }: TrequestResponse) => {
     const { article_id } = get_article_by_id_params_schema.parse(req.params);
-    // const { user_id } = get_article_by_id_query_schema.parse(req.query);
+    const { user_id } = get_article_by_id_query_schema.parse(req.query);
 
     const article = await mg.Article.findById<TArticleWithPopulatedAuthors>(article_id)
         .populate('author', 'name email profileImage bio role socialLinks')
@@ -109,7 +109,7 @@ export const get_article_by_id = async ({ req, res }: TrequestResponse) => {
         });
     }
 
-    // const user_reaction = article!.reactions?.find(reaction => reaction.user_id.toString() === user_id) || null;
+    const user_reaction = article!.reactions?.filter((reaction) => reaction.user_id.toString() === user_id);
 
     const formatted_article: TFormattedArticle = {
         id: article!._id,
@@ -120,7 +120,7 @@ export const get_article_by_id = async ({ req, res }: TrequestResponse) => {
         collection_id: article!.collection_id,
         tags: article!.tags,
         read_time: article!.readTime,
-        // reactions: user_reaction,
+        reaction: user_reaction?.[0],
         created_at: article!.createdAt,
         updated_at: article!.updatedAt
     };

--- a/src/controllers/news/get-news-by-id.ts
+++ b/src/controllers/news/get-news-by-id.ts
@@ -2,14 +2,62 @@ import { z } from 'zod';
 import { mg } from '../../config/mg';
 import { TrequestResponse } from '../../types/shared';
 import { throw_error } from '../../utils/throw-error';
-// import { NewsReactionItem } from '../../models/news';
+import { NewsReactionItem } from '../../models/news';
+import { Schema } from 'mongoose';
+
+type TPopulatedAuthor = {
+    _id: Schema.Types.ObjectId;
+    name: string;
+    profileImage: string;
+    bio: string;
+    role: string;
+}
+
+
+type TFormattedNews = {
+    id: Schema.Types.ObjectId;
+    title: string;
+    slug: string;
+    content: string;
+    imageUrl: string;
+    thumbnailUrl: string;
+    author: TPopulatedAuthor;
+    category: string;
+    tags: string[];
+    publishedAt: Date;
+    isPublished: boolean;
+    isFeatured: boolean;
+    readTime: number;
+    reaction?: NewsReactionItem;
+}
+
+type TNewsWithPopulatedAuthors = {
+    _id: Schema.Types.ObjectId;
+    title: string;
+    slug: string;
+    content: string;
+    imageUrl: string;
+    thumbnailUrl: string;
+    author: TPopulatedAuthor;
+    category: string;
+    tags: string[];
+    publishedAt: Date;
+    isPublished: boolean;
+    isFeatured: boolean;
+    readTime: number;
+    reactions: NewsReactionItem[];
+}
+
+
+
+
 
 export const get_news_by_id = async ({ req, res }: TrequestResponse) => {
 
     const { id } = get_news_by_id_schema.parse(req.params);
-    // const { user_id } = get_news_by_id_query_schema.parse(req.query);
-    const news = await mg.News.findById(id)
-        .populate('author', 'name profileImage')
+    const { user_id } = get_news_by_id_query_schema.parse(req.query);
+    const news = await mg.News.findById<TNewsWithPopulatedAuthors>(id)
+        .populate('author')
         .exec();
 
     if (!news) {
@@ -22,26 +70,29 @@ export const get_news_by_id = async ({ req, res }: TrequestResponse) => {
         return; // This line will never be reached, but helps TypeScript
     }
 
-    // const user_reaction = news.reactions.find(reaction => reaction.user_id.toString() === user_id);
+    const user_reaction = news!.reactions?.filter((newsReaction) => newsReaction.user_id.toString() === user_id);
+
+    const formatted_news: TFormattedNews = {
+        id: news._id,
+        title: news.title,
+        slug: news.slug,
+        content: news.content,
+        imageUrl: news.imageUrl,
+        thumbnailUrl: news.thumbnailUrl,
+        author: news.author,
+        category: news.category,
+        tags: news.tags,
+        publishedAt: news.publishedAt,
+        isPublished: news.isPublished,
+        isFeatured: news.isFeatured,
+        readTime: news.readTime,
+        reaction: user_reaction?.[0],
+    }
+
 
     res.status(200).json({
         message: "News retrieved successfully",
-        data: {
-            id: news._id,
-            title: news.title,
-            slug: news.slug,
-            content: news.content,
-            imageUrl: news.imageUrl,
-            thumbnailUrl: news.thumbnailUrl,
-            author: news.author,
-            category: news.category,
-            tags: news.tags,
-            publishedAt: news.publishedAt,
-            isPublished: news.isPublished,
-            isFeatured: news.isFeatured,
-            readTime: news.readTime,
-            // reactions: user_reaction
-        }
+        data: formatted_news
     });
 
 }


### PR DESCRIPTION
- Updated reaction types in TArticleWithPopulatedAuthors and TFormattedArticle to support multiple reactions.
- Modified get_article_by_id and get_news_by_id functions to filter user reactions correctly.
- Cleaned up commented-out code and ensured consistent formatting across both controllers.