### PR TITLE
Add get_top_articles controller and route for retrieving top articles

### DIFF
--- a/src/controllers/help/get-top-articles.ts
+++ b/src/controllers/help/get-top-articles.ts
@@ -1,0 +1,43 @@
+import { mg } from '../../config/mg';
+import { TrequestResponse } from '../../types/shared';
+import { Schema } from 'mongoose';
+
+type TArticle = {
+    _id: Schema.Types.ObjectId;
+    title: string;
+};
+
+type TFormattedArticle = {
+    id: Schema.Types.ObjectId;
+    title: string;
+};
+
+type TResponseData = {
+    articles: TFormattedArticle[];
+    total_count: number;
+};
+
+export const get_top_articles = async ({ req, res }: TrequestResponse) => {
+    // Get the 4 newest published articles - only ID and title
+    const articles = await mg.Article.find<TArticle>({
+        isPublished: true
+    })
+        .select('_id title')
+        .sort({ createdAt: -1 })
+        .limit(4);
+
+    const formatted_articles: TFormattedArticle[] = articles.map(article => ({
+        id: article._id,
+        title: article.title
+    }));
+
+    const response_data: TResponseData = {
+        articles: formatted_articles,
+        total_count: formatted_articles.length
+    };
+
+    res.status(200).json({
+        message: "Top articles retrieved successfully",
+        data: response_data
+    });
+};

--- a/src/routes/help.ts
+++ b/src/routes/help.ts
@@ -5,11 +5,13 @@ import { get_collection_by_id } from "../controllers/help/get-collection-by-id";
 import { get_article_by_id } from "../controllers/help/get-article-by-id";
 import { submit_article_reaction } from "../controllers/help/submit-article-reaction";
 import { get_articles_by_search } from "../controllers/help/get-articles-by-search";
+import { get_top_articles } from "../controllers/help/get-top-articles";
 
 const router = Router();
 
 router.get('/collections', async_handler(get_all_collections));
 router.get('/collections/:collection_id', async_handler(get_collection_by_id));
+router.get('/articles/top', async_handler(get_top_articles));
 router.get('/articles/search', async_handler(get_articles_by_search));
 router.get('/articles/:article_id', async_handler(get_article_by_id));
 router.post('/articles/:article_id/reaction', async_handler(submit_article_reaction));


### PR DESCRIPTION
- Implemented get_top_articles function to fetch the 4 newest published articles with their IDs and titles.
- Added a new route '/articles/top' to access the top articles endpoint.
- Structured response to include total count of articles retrieved.