### PR TITLE
Implement cursor-based pagination in collection, conversation, news, …

### DIFF
--- a/src/controllers/collection/get-all-collections.ts
+++ b/src/controllers/collection/get-all-collections.ts
@@ -1,35 +1,48 @@
 import { Request, Response } from 'express';
+import { Types } from 'mongoose';
 
 import { mg } from '@/config/mg';
 import { throw_error } from '@/utils/throw-error';
 import { TCollection } from '@/models/collection';
-import { z_pagination } from '@/utils/schema';
+import { z_infinite_scroll } from '@/utils/schema';
+
+type TQuery = {
+    level: number;
+    is_published: boolean;
+    _id?: { $gt: Types.ObjectId };
+}
 
 export const get_all_collections = async (req: Request, res: Response) => {
 
-    const { page, limit } = z_pagination().parse(req.query);
+    const { limit, cursor } = z_infinite_scroll().parse(req.query);
 
-    const collections = mg.Collection.find<TCollection>({
+    // Build query with cursor-based pagination
+    const query: TQuery = {
         level: 0,
         is_published: true
-    })
+    };
+
+    // Add cursor condition for pagination
+    if (cursor) {
+        query._id = { $gt: cursor }; // Using $gt for ascending order (title: 1)
+    }
+
+    const collections = await mg.Collection.find<TCollection>(query)
         .select('title description slug icon total_articles')
-        .skip((page - 1) * limit)
-        .limit(limit)
-        .sort({ title: 1 });
+        .limit(limit + 1) // Get one extra to check if there are more
+        .sort({ title: 1, _id: 1 });
 
-    const get_total_collections = mg.Collection.countDocuments({
-        level: 0,
-        is_published: true
-    });
-
-    const [collections_data, total_collections] = await Promise.all([collections, get_total_collections]);
-
-    if (!collections_data) {
+    if (!collections) {
         throw_error('Collections not found', 404);
     }
 
-    const formatted_collections = collections_data.map(collection => ({
+    // Check if there are more results
+    const has_more = collections.length > limit;
+    const collections_to_return = has_more ? collections.slice(0, -1) : collections;
+    const next_cursor = has_more && collections_to_return.length > 0 ?
+        collections_to_return[collections_to_return.length - 1]?._id?.toString() || null : null;
+
+    const formatted_collections = collections_to_return.map(collection => ({
         id: collection._id,
         title: collection.title,
         description: collection.description,
@@ -38,16 +51,13 @@ export const get_all_collections = async (req: Request, res: Response) => {
         article_count: collection.total_articles
     }));
 
-    const total_pages = Math.ceil(total_collections / limit);
-
     res.status(200).json({
         message: "Root collections retrieved successfully",
         data: formatted_collections,
-        pagination: {
-            page,
-            limit,
-            total_pages,
-            total_collections
+        infinite_scroll: {
+            has_more,
+            next_cursor,
+            limit
         }
     });
 

--- a/src/controllers/conversations/get-all-conversations.ts
+++ b/src/controllers/conversations/get-all-conversations.ts
@@ -1,45 +1,56 @@
 import { Request, Response } from 'express';
+import { Types } from 'mongoose';
 import { z } from 'zod';
 
 import { mg } from '@/config/mg';
 import { throw_error } from '@/utils/throw-error';
 import { TConversation } from '@/models/conversation';
-import { z_pagination, z_object_id } from '@/utils/schema';
+import { z_infinite_scroll, z_object_id } from '@/utils/schema';
+import { TConversationStatus } from '@/types/conversation';
+
+type TQuery = {
+    user_id: Types.ObjectId;
+    status: TConversationStatus;
+    _id?: { $lt: Types.ObjectId };
+}
 
 export const get_all_conversations = async (req: Request, res: Response) => {
 
-    const { page, limit, user_id } = z_get_all_conversations_query_schema.parse(req.query);
+    const { limit, cursor, user_id } = z_get_all_conversations_query_schema.parse(req.query);
 
-    const conversations = mg.Conversation.find<TConversation>({
+    // Build query with cursor-based pagination
+    const query: TQuery = {
         user_id: user_id,
         status: 'active'
-    })
+    };
+
+    // Add cursor condition for pagination
+    if (cursor) {
+        query._id = { $lt: cursor }; // Using $lt for descending order (updatedAt: -1)
+    }
+
+    const conversations = await mg.Conversation.find<TConversation>(query)
         .select('title user_id status updatedAt')
-        .skip((page - 1) * limit)
-        .limit(limit)
-        .sort({ updatedAt: -1 }).lean();
+        .limit(limit + 1) // Get one extra to check if there are more
+        .sort({ updatedAt: -1, _id: -1 }).lean();
 
-    const get_total_conversations = mg.Conversation.countDocuments({
-        user_id: user_id,
-        status: 'active'
-    });
-
-    const [conversations_data, total_conversations] = await Promise.all([conversations, get_total_conversations]);
-
-    if (conversations_data.length === 0) {
+    if (conversations.length === 0) {
         throw_error('Conversations not found', 404);
     }
 
-    const total_pages = Math.ceil(total_conversations / limit);
+    // Check if there are more results
+    const has_more = conversations.length > limit;
+    const conversations_to_return = has_more ? conversations.slice(0, -1) : conversations;
+    const next_cursor = has_more && conversations_to_return.length > 0 ?
+        conversations_to_return[conversations_to_return.length - 1]?._id?.toString() || null : null;
 
     res.status(200).json({
         message: "Active conversations retrieved successfully",
-        data: conversations_data,
-        pagination: {
-            page,
-            limit,
-            total_pages,
-            total_conversations
+        data: conversations_to_return,
+        infinite_scroll: {
+            has_more,
+            next_cursor,
+            limit
         }
     });
 
@@ -47,4 +58,4 @@ export const get_all_conversations = async (req: Request, res: Response) => {
 
 const z_get_all_conversations_query_schema = z.object({
     user_id: z_object_id
-}).merge(z_pagination());
+}).merge(z_infinite_scroll());

--- a/src/controllers/news/get-all-news.ts
+++ b/src/controllers/news/get-all-news.ts
@@ -1,30 +1,45 @@
 import { Request, Response } from 'express';
+import { Types } from 'mongoose';
 
 import { mg } from '@/config/mg';
 import { throw_error } from '@/utils/throw-error';
 import { TNews } from '@/models/news';
-import { z_pagination } from '@/utils/schema';
+import { z_infinite_scroll } from '@/utils/schema';
+
+type TQuery = {
+    is_published: boolean;
+    _id?: { $lt: Types.ObjectId };
+};
 
 export const get_all_news = async (req: Request, res: Response) => {
 
-    const { page, limit } = z_pagination().parse(req.query);
+    const { limit, cursor } = z_infinite_scroll().parse(req.query);
 
-    const news = mg.News.find<TNews>({ is_published: true })
+    // Build query with cursor-based pagination
+    const query: TQuery = { is_published: true };
+
+    // Add cursor condition for pagination
+    if (cursor) {
+        query._id = { $lt: cursor }; // Using $lt for descending order (published_at: -1)
+    }
+
+    const news = await mg.News.find<TNews>(query)
         .select('title slug content image_url tags _id')
-        .skip((page - 1) * limit)
-        .limit(limit)
-        .sort({ published_at: -1 });
+        .limit(limit + 1) // Get one extra to check if there are more
+        .sort({ published_at: -1, _id: -1 });
 
-    const get_total_news = mg.News.countDocuments({ is_published: true });
-
-    const [news_data, total_news] = await Promise.all([news, get_total_news]);
-
-    if (!news_data) {
+    if (!news) {
         throw_error('News not found', 404);
     }
 
+    // Check if there are more results
+    const has_more = news.length > limit;
+    const news_to_return = has_more ? news.slice(0, -1) : news;
+    const next_cursor = has_more && news_to_return.length > 0 ?
+        news_to_return[news_to_return.length - 1]?._id?.toString() || null : null;
+
     // Truncate content to 3 lines (approximately 150 characters)
-    const formatted_news = news_data.map(item => ({
+    const formatted_news = news_to_return.map(item => ({
         id: item._id,
         title: item.title,
         slug: item.slug,
@@ -33,16 +48,13 @@ export const get_all_news = async (req: Request, res: Response) => {
         description: item.content.length
     }));
 
-    const total_pages = Math.ceil(total_news / limit);
-
     res.status(200).json({
         message: "News retrieved successfully",
         data: formatted_news,
-        pagination: {
-            page,
-            limit,
-            total_pages,
-            total_news
+        infinite_scroll: {
+            has_more,
+            next_cursor,
+            limit
         }
     });
 

--- a/src/models/article.ts
+++ b/src/models/article.ts
@@ -2,7 +2,7 @@ import { Document, model, Schema } from "mongoose";
 
 import { update_collection_article_count } from "@/utils/update-collection-article-count";
 import { ARTICLE_REACTIONS } from "@/constants/reactions";
-import { ArticleReaction, ArticleReactionItem } from "@/types/reactions";
+import { TArticleReactionItem } from "@/types/reactions";
 
 type TArticle = Document & {
     title: string;
@@ -16,7 +16,7 @@ type TArticle = Document & {
     tags: string[];
     read_time: number;
     is_published: boolean;
-    reactions: ArticleReactionItem[];
+    reactions: TArticleReactionItem[];
 }
 
 

--- a/src/models/author.ts
+++ b/src/models/author.ts
@@ -23,7 +23,6 @@ const authorSchema = new Schema<TAuthor>({
     email: {
         type: String,
         required: true,
-        unique: true,
         lowercase: true
     },
     profile_image: {

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -25,3 +25,26 @@ export const z_pagination = (page = '1', limit = '20') =>
                 message: 'Limit must be greater than or equal to 1'
             })
     })
+
+export const z_infinite_scroll = (limit = '20') =>
+    z.object({
+        limit: z
+            .string()
+            .optional()
+            .default(limit)
+            .transform(Number)
+            .refine((val) => val >= 1 && val <= 100, {
+                message: 'Limit must be between 1 and 100'
+            }),
+        cursor: z
+            .string()
+            .optional()
+            .nullable()
+            .refine((val) => {
+                if (!val) return true; // Allow null/undefined
+                return /^[0-9a-fA-F]{24}$/.test(val); // Valid ObjectId format
+            }, {
+                message: 'Invalid cursor format'
+            })
+            .transform((val) => val ? new Types.ObjectId(val) : null)
+    })


### PR DESCRIPTION
…and post controllers

- Refactored the get_all_collections, get_all_conversations, get_all_news, and get_posts functions to utilize cursor-based pagination instead of page-based pagination.
- Updated query structures to support cursor parameters for more efficient data retrieval.
- Adjusted response formats to include infinite scroll properties such as has_more and next_cursor.
- Enhanced type safety by defining query types for each controller.
- Removed deprecated pagination logic and related imports for improved clarity and performance.